### PR TITLE
fix: Eliminate portfolio background color bleed

### DIFF
--- a/src/app/portfolio/components/PortfolioBodyStyle.tsx
+++ b/src/app/portfolio/components/PortfolioBodyStyle.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useEffect } from "react";
+
+const PORTFOLIO_BG = "#070b13";
+
+/**
+ * Overrides the body background color for the portfolio route.
+ * On mount, sets body to the dark portfolio color; on unmount, restores the sky blue.
+ */
+export default function PortfolioBodyStyle() {
+  useEffect(() => {
+    const prev = document.body.style.backgroundColor;
+    document.body.style.backgroundColor = PORTFOLIO_BG;
+    return () => {
+      document.body.style.backgroundColor = prev;
+    };
+  }, []);
+
+  return null;
+}

--- a/src/app/portfolio/components/PortfolioContent.tsx
+++ b/src/app/portfolio/components/PortfolioContent.tsx
@@ -45,8 +45,8 @@ export default function PortfolioContent() {
     <>
       <AllowScroll />
       <motion.div
-        className="min-h-screen font-syne"
-        style={{ background: '#070b13' }}
+        className="font-syne"
+        style={{ background: '#070b13', minHeight: '100dvh' }}
         initial={{ opacity: 0, y: 16 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.4, ease: [0.23, 1, 0.32, 1] }}
@@ -57,6 +57,7 @@ export default function PortfolioContent() {
           style={{
             background: 'rgba(7,11,19,0.88)',
             borderBottom: '1px solid rgba(255,255,255,0.06)',
+            paddingTop: 'env(safe-area-inset-top, 0px)',
           }}
         >
           <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">

--- a/src/app/portfolio/layout.tsx
+++ b/src/app/portfolio/layout.tsx
@@ -1,0 +1,14 @@
+import PortfolioBodyStyle from "./components/PortfolioBodyStyle";
+
+export default function PortfolioLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <PortfolioBodyStyle />
+      {children}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `PortfolioBodyStyle` client component that overrides `body` background to dark (`#070b13`) on mount and restores sky blue on unmount
- Creates `portfolio/layout.tsx` to apply the override at the route level, eliminating the light blue flash during navigation
- Switches portfolio container to `100dvh` for proper mobile viewport coverage and adds `safe-area-inset-top` padding to the fixed nav for notch devices

## Test plan
- [ ] Navigate from landing page to `/portfolio` — no light blue flash visible
- [ ] On mobile, verify no light blue in status bar / safe area
- [ ] Navigate back to home — sky blue background restores correctly
- [ ] Check desktop and mobile viewports for consistent dark background
- [ ] Verify boat adventure pages still show sky blue background

🤖 Generated with [Claude Code](https://claude.com/claude-code)